### PR TITLE
密码存储格式变化

### DIFF
--- a/Chapter4-3-1/src/main/java/com/didispace/WebSecurityConfig.java
+++ b/Chapter4-3-1/src/main/java/com/didispace/WebSecurityConfig.java
@@ -30,7 +30,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
         auth
             .inMemoryAuthentication()
-                .withUser("user").password("password").roles("USER");
+            .passwordEncoder(new BCryptPasswordEncoder()).withUser("user").password(new BCryptPasswordEncoder().encode("123456")).roles("USER");
     }
 
 }


### PR DESCRIPTION
报错：There is no PasswordEncoder mapped for the id “null”。解决：spring security中的所有默认的密码格式都是在PasswordEncoderFactories这个 类中，可以进入这个类中查看